### PR TITLE
Reworking dropdown popups for account table

### DIFF
--- a/user_interface/static/javascript/accounts_popups.js
+++ b/user_interface/static/javascript/accounts_popups.js
@@ -66,23 +66,7 @@ function createTypeOptionsPopup(baseApiUrl, accessToken, cell) {
             const id = selectedOption.dataset.id;
             // Store the id in a custom attribute of the cell
             cell.setAttribute('data-id', id);
-            // Remove the select from the DOM
-            document.body.removeChild(select);
         });
-
-        // Add event listener to handle clicks outside the dropdown
-        const closePopup = function (event) {
-            if (!select.contains(event.target)) {
-                document.removeEventListener('click', closePopup);
-                // Check if the select is still a child before removing
-                if (document.body.contains(select)) {
-                    document.body.removeChild(select);
-                }
-            }
-        };
-
-        // Add event listener to handle clicks outside the dropdown
-        document.addEventListener('click', closePopup);
     })
     .catch(error => {
         console.error('Error fetching options:', error);

--- a/user_interface/static/javascript/accounts_utils.js
+++ b/user_interface/static/javascript/accounts_utils.js
@@ -40,17 +40,29 @@ export function populateRowCells(row, account, baseApiUrl, accessToken, empty=fa
                 cell.textContent = account[key];
             }
             cell.setAttribute('header', key);
+
             if (constants.editableAccountFields.includes(key)) {
-                cell.addEventListener('click', function (clickedCell) {
-                    return function () {
-                        createInputPopup(
-                            baseApiUrl,
-                            accessToken,
-                            clickedCell,
-                            getCurrentAccountKey(clickedCell, account)
-                        );
-                    };
-                }(cell));
+                // Add popup for column when page loads
+                if (constants.popupOnLoadFields.includes(key)) {
+                    createInputPopup(
+                        baseApiUrl,
+                        accessToken,
+                        cell,
+                        getCurrentAccountKey(cell, account)
+                    );
+                // For other cells, attach a click event listener
+                } else {
+                    cell.addEventListener('click', function (clickedCell) {
+                        return function () {
+                            createInputPopup(
+                                baseApiUrl,
+                                accessToken,
+                                clickedCell,
+                                getCurrentAccountKey(clickedCell, account)
+                            );
+                        };
+                    }(cell));
+                }
             }
         }
     }

--- a/user_interface/static/javascript/constants.js
+++ b/user_interface/static/javascript/constants.js
@@ -21,7 +21,13 @@ const editableAccountFields = [
     'description'
 ]
 
+// Fields that need a popup on page load
+const popupOnLoadFields = [
+    'type_name'
+]
+
 export {
     viewableAccountFields,
-    editableAccountFields
+    editableAccountFields,
+    popupOnLoadFields
 };


### PR DESCRIPTION
The dropdown popups are now loaded on page load for the type_name column and stay on even when user clicks away.