### PR TITLE
Adding support for running automated tests in docker container

### DIFF
--- a/db_dumps/grants.sql
+++ b/db_dumps/grants.sql
@@ -1,0 +1,8 @@
+-- Granting permissions to sppaskal user to manage test databases.
+-- This is required when running automated tests in docker container.
+
+-- Make sure this file is loaded after the authentication database
+-- as the user it references will not exist otherwise.
+
+GRANT ALL PRIVILEGES ON `test_%`.* TO 'sppaskal'@'%';
+FLUSH PRIVILEGES;

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,6 +17,7 @@ services:
       - "3307:3306"
     volumes:
       - ./db_dumps/auth_db.sql:/docker-entrypoint-initdb.d/auth_db.sql
+      - ./db_dumps/grants.sql:/docker-entrypoint-initdb.d/grants.sql
       - mysql_auth_db_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     image: mysql:8.0.34
@@ -32,6 +33,7 @@ services:
       - "3308:3306"
     volumes:
       - ./db_dumps/account_information.sql:/docker-entrypoint-initdb.d/account_information.sql
+      - ./db_dumps/grants.sql:/docker-entrypoint-initdb.d/grants.sql
       - mysql_account_information_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     image: mysql:8.0.34

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "3307:3306"
     volumes:
       - ./db_dumps/auth_db.sql:/docker-entrypoint-initdb.d/auth_db.sql
+      - ./db_dumps/grants.sql:/docker-entrypoint-initdb.d/grants.sql
       - mysql_auth_db_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     image: mysql:8.0.34
@@ -26,6 +27,7 @@ services:
       - "3308:3306"
     volumes:
       - ./db_dumps/account_information.sql:/docker-entrypoint-initdb.d/account_information.sql
+      - ./db_dumps/grants.sql:/docker-entrypoint-initdb.d/grants.sql
       - mysql_account_information_data:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password
     image: mysql:8.0.34


### PR DESCRIPTION
- Added a grants.sql file which grants permission to the 'sppaskal' user to manage test databases
- Updated both the dev and main docker-compose files to load the grants.sql file